### PR TITLE
Updated code errors in issue #40

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,7 +132,7 @@ export default function changeCount(state = {
 
     default:
       return state;
-  };
+  }
 };
 ```
 
@@ -190,7 +190,7 @@ So we'll do the following:
         <button onClick={handleOnClick}>
           Click Me
         </button>
-        <div>{props.store.getState().count}</div>
+        <div>{props.store.getState() ? props.store.getState().count : 0}</div>
       </div>
     )
   };


### PR DESCRIPTION
There were 2 errors:

- `changeCount.js` -  an extra `;` was placed at the end of the switch statement
- `Counter.js` - before state was initialized, the original code `{props.store.getState().count` returns undefined.  Changed this line of code to `{props.store.getState() ? props.store.getState().count : 0}` per @howardbdev 's suggestion in issue #40 